### PR TITLE
Use System.loadLibrary to load libfwknop.so

### DIFF
--- a/app/src/main/java/biz/incomsystems/fwknop2/SendSPA.java
+++ b/app/src/main/java/biz/incomsystems/fwknop2/SendSPA.java
@@ -193,7 +193,7 @@ public class SendSPA implements OnSessionStartedListener, OnSessionFinishedListe
             InetAddressValidator ipValidate = new InetAddressValidator();
 
             try {
-                System.load(mActivity.getFilesDir().getParentFile().getPath() + "/lib/libfwknop.so");
+                System.loadLibrary("fwknop");
             } catch (Exception ex) {
                 Log.e("fwknop2", "Could not load libfko: " + ex);
             }


### PR DESCRIPTION
Changed to use loadLibrary as the app crashes on an arm64 device with error:

```
11-05 20:01:22.574 12896 12909 E AndroidRuntime: FATAL EXCEPTION: AsyncTask #1
11-05 20:01:22.574 12896 12909 E AndroidRuntime: Process: org.cipherdyne.fwknop2, PID: 12896
11-05 20:01:22.574 12896 12909 E AndroidRuntime: java.lang.RuntimeException: An error occurred while executing doInBackground()
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at android.os.AsyncTask$3.done(AsyncTask.java:309)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:354)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at java.util.concurrent.FutureTask.setException(FutureTask.java:223)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at java.util.concurrent.FutureTask.run(FutureTask.java:242)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:234)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at java.lang.Thread.run(Thread.java:818)
11-05 20:01:22.574 12896 12909 E AndroidRuntime: Caused by: java.lang.UnsatisfiedLinkError: dlopen failed: library "/data/user/0/org.cipherdyne.fwknop2/lib/libfwknop.so" not found
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at java.lang.Runtime.load(Runtime.java:332)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at java.lang.System.load(System.java:1069)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at biz.incomsystems.fwknop2.SendSPA$getExternalIP.doInBackground(SendSPA.java:198)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at biz.incomsystems.fwknop2.SendSPA$getExternalIP.doInBackground(SendSPA.java:175)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at android.os.AsyncTask$2.call(AsyncTask.java:295)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        at java.util.concurrent.FutureTask.run(FutureTask.java:237)
11-05 20:01:22.574 12896 12909 E AndroidRuntime:        ... 4 more

```